### PR TITLE
Add switches to disable auth rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -354,6 +354,10 @@ LOGIN_MAX=7
 LOGIN_WINDOW=5
 REGISTER_MAX=5
 REGISTER_WINDOW=60
+# Set to true to disable login rate limiting
+DISABLE_LOGIN_LIMITER=false
+# Set to true to disable registration rate limiting
+DISABLE_REGISTER_LIMITER=false
 
 LIMIT_CONCURRENT_MESSAGES=true
 CONCURRENT_MESSAGE_MAX=2

--- a/api/server/middleware/limiters/loginLimiter.js
+++ b/api/server/middleware/limiters/loginLimiter.js
@@ -1,6 +1,15 @@
 const rateLimit = require('express-rate-limit');
 const { RedisStore } = require('rate-limit-redis');
 const { removePorts, isEnabled } = require('~/server/utils');
+
+// Early exit if the login rate limiter has been disabled
+if (
+  isEnabled(process.env.DISABLE_LOGIN_LIMITER) ||
+  isEnabled(process.env.DISABLE_RATE_LIMITERS)
+) {
+  module.exports = (req, res, next) => next();
+}
+
 const ioredisClient = require('~/cache/ioredisClient');
 const { logViolation } = require('~/cache');
 const { logger } = require('~/config');

--- a/api/server/middleware/limiters/registerLimiter.js
+++ b/api/server/middleware/limiters/registerLimiter.js
@@ -1,6 +1,15 @@
 const rateLimit = require('express-rate-limit');
 const { RedisStore } = require('rate-limit-redis');
 const { removePorts, isEnabled } = require('~/server/utils');
+
+// Early exit if the registration rate limiter has been disabled
+if (
+  isEnabled(process.env.DISABLE_REGISTER_LIMITER) ||
+  isEnabled(process.env.DISABLE_RATE_LIMITERS)
+) {
+  module.exports = (req, res, next) => next();
+}
+
 const ioredisClient = require('~/cache/ioredisClient');
 const { logViolation } = require('~/cache');
 const { logger } = require('~/config');


### PR DESCRIPTION
## Summary
- allow disabling login and registration rate limiters via env vars
- document the new variables in `.env.example`

## Testing
- `npm run test:api` *(fails: Multer Configuration & tokenSplit timeouts)*

